### PR TITLE
Disable Deployment to AWS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,17 +12,16 @@ before_install:
 # run test suite
 script:
   - docker run -e CI=true dtrambaud/docker-reactjs npm run test
-
 # deploy (to aws)
-deploy:
-  provider: elasticbeanstalk
-  region: "us-east-2"
-  app: "docker-react"
-  env: "DockerReact-env"
-  bucket_name: "elasticbeanstalk-us-east-2-195465432763"
-  bucket_path: "docker-react"
-  on:
-    branch: master
-  access_key_id: $AWS_ACCESS_KEY
-  secret_access_key:
-    secure: $AWS_SECRET_KEY
+# deploy:
+#   provider: elasticbeanstalk
+#   region: "us-east-2"
+#   app: "docker-react"
+#   env: "DockerReact-env"
+#   bucket_name: "elasticbeanstalk-us-east-2-195465432763"
+#   bucket_path: "docker-react"
+#   on:
+#     branch: master
+#   access_key_id: $AWS_ACCESS_KEY
+#   secret_access_key:
+#     secure: $AWS_SECRET_KEY


### PR DESCRIPTION
- Comment out Travis CI deployment task to avoid deploying to AWS Elastic Beanstalk