### PR TITLE
Orchestrate Multi-Container Continuous Deployment to AWS Beanstalk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,20 @@ after_success:
   - docker push dtrambaud/multi-nginx
   - docker push dtrambaud/multi-daemon
   - docker push dtrambaud/multi-server
+
+deploy:
+  provider: elasticbeanstalk
+  region: "us-east-2"
+  app: "multi-container-docker"
+  env: "MultiContainerDocker-env"
+  bucket_name: "elasticbeanstalk-us-east-2-195465432763"
+  bucket_path: "multi-container-docker"
+  on:
+    branch: master
+  access_key_id:
+    secure: $AWS_ACCESS_KEY
+  secret_access_key:
+    secure: $AWS_SECRET_KEY
 # Deploy to single container instance ...
 # deploy (to aws)
 # deploy:

--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -5,19 +5,22 @@
       "name": "client",
       "image": "dtrambaud/multi-client",
       "hostname": "client",
-      "essential": false
+      "essential": false,
+      "memory": 128
     },
     {
       "name": "daemon",
       "image": "dtrambaud/multi-daemon",
       "hostname": "worker",
-      "essential": false
+      "essential": false,
+      "memory": 128
     },
     {
       "name": "server",
       "image": "dtrambaud/multi-server",
       "hostname": "api",
-      "essential": false
+      "essential": false,
+      "memory": 128
     },
     {
       "name": "nginx",
@@ -29,7 +32,8 @@
           "containerPort": 80
         }
       ],
-      "links": ["client", "server"]
+      "links": ["client", "server"],
+      "memory": 128
     }
   ]
 }

--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -1,0 +1,35 @@
+{
+  "AWSEBDockerrunVersion": 2,
+  "containerDefinitions": [
+    {
+      "name": "client",
+      "image": "dtrambaud/multi-client",
+      "hostname": "client",
+      "essential": false
+    },
+    {
+      "name": "daemon",
+      "image": "dtrambaud/multi-daemon",
+      "hostname": "worker",
+      "essential": false
+    },
+    {
+      "name": "server",
+      "image": "dtrambaud/multi-server",
+      "hostname": "api",
+      "essential": false
+    },
+    {
+      "name": "nginx",
+      "image": "dtrambaud/multi-nginx",
+      "essential": true,
+      "portMappings": [
+        {
+          "hostPort": 80,
+          "containerPort": 80
+        }
+      ],
+      "links": ["client", "server"]
+    }
+  ]
+}


### PR DESCRIPTION
- Add Dockerrun.aws.json (AWS ECS task definition file)
- Add deployment step to .travis.yml
- Set amount of memory to allocate for each service/container on AWS